### PR TITLE
Add proper parsing of X-Forwarded-For

### DIFF
--- a/internal/web/healthcheck_handler.go
+++ b/internal/web/healthcheck_handler.go
@@ -80,7 +80,7 @@ func handleInfo(ctx *fasthttp.RequestCtx) {
 	info := map[string]interface{}{
 		"name":       "GoIAM",
 		"go_version": runtime.Version(),
-		"user_ip":    ctx.UserValue("user_ip"),
+		"user_ip":    ctx.UserValue("remote_ip"),
 	}
 
 	// list available services and their implementaitons with service.GetServices()

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -106,12 +106,6 @@ func New() *router.Router {
 	// handleNotFound is the fallback handler for unmatched routes
 	redirectUrl = config.GetNotFoundRedirectUrl()
 	r.NotFound = WrapMiddleware(func(ctx *fasthttp.RequestCtx) {
-		if config.IsXForwardedForEnabled() {
-			// Use X-Forwarded-For header if enabled
-			if xff := ctx.Request.Header.Peek("X-Forwarded-For"); xff != nil {
-				ctx.SetUserValue("remote_ip", string(xff))
-			}
-		}
 
 		if redirectUrl != "" {
 			ctx.Redirect(redirectUrl, fasthttp.StatusSeeOther)


### PR DESCRIPTION
This commit also deprecates `GOIAM_USE_X_FORWARDED_FOR`, as more information is needed to parse `X-Forwarded-For` such as the number of trusted proxies between your application and the internet. 

I've instead created the `GOIAM_PROXIES` env variable and added a middleware to determine client ip address which is put into `remote_ip` rather than a mix of `remote_ip` and `user_ip`, I've added tests and some comments :)


I am not sure if I found all usages of `remote_ip` and `user_ip` as I havent used fasthttp before. Hopefully this works! Ps Pritches sent me :P